### PR TITLE
mit -> MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A MagicMirror² module to show a custom message.",
   "main": "MMM-CustomText.js",
   "author": "dathbe",
-  "license": "mit",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dathbe/MMM-CustomText.git"


### PR DESCRIPTION
License should be indicated by a valid SPDX license identifier: https://spdx.org/licenses/